### PR TITLE
Fix collaboration markdown parsing

### DIFF
--- a/src/components/Collaborations.tsx
+++ b/src/components/Collaborations.tsx
@@ -7,10 +7,6 @@ import { Card, CardContent } from "@/components/ui/card";
 
 const Collaborations = () => {
   const content = useMemo(() => getCollaborationsContent(), []);
-  
-  if (!content) {
-    return null;
-  }
 
   interface CollaborationPreview {
     name: string;
@@ -21,6 +17,7 @@ const Collaborations = () => {
   }
 
   const collaborationPreviews = useMemo<CollaborationPreview[]>(() => {
+    if (!content) return [];
     const markdown = content.content;
     const section = markdown.split("## Active Collaborations")[1];
     if (!section) return [];
@@ -50,9 +47,15 @@ const Collaborations = () => {
     });
   }, [content]);
 
+  if (!content) {
+    return null;
+  }
+
   // Extract title and description from content
   const sectionTitle = "Global Collaborations";
-  const sectionDescription = content.description || "Partnering with leading institutions and organizations worldwide to accelerate cancer immunotherapy research and bring AI-driven solutions to patients faster.";
+  const sectionDescription =
+    content.description ||
+    "Partnering with leading institutions and organizations worldwide to accelerate cancer immunotherapy research and bring AI-driven solutions to patients faster.";
 
   return (
     <section id="collaborations" className="py-20 bg-muted/30">

--- a/src/components/ResourcesTools.tsx
+++ b/src/components/ResourcesTools.tsx
@@ -15,10 +15,6 @@ import { Card, CardContent } from "@/components/ui/card";
 
 const ResourcesTools = () => {
   const content = useMemo(() => getResourcesContent(), []);
-  
-  if (!content) {
-    return null;
-  }
 
   interface ToolPreview {
     name: string;
@@ -30,6 +26,7 @@ const ResourcesTools = () => {
   }
 
   const toolPreviews = useMemo<ToolPreview[]>(() => {
+    if (!content) return [];
     const markdown = content.content;
 
     const extractPreview = (
@@ -68,9 +65,15 @@ const ResourcesTools = () => {
     ].filter((p): p is ToolPreview => Boolean(p));
   }, [content]);
 
+  if (!content) {
+    return null;
+  }
+
   // Extract title and description from content
   const sectionTitle = "Research Resources & Tools";
-  const sectionDescription = content.description || "Open-source tools, datasets, and documentation to advance computational immunooncology research. All resources are freely available to the scientific community.";
+  const sectionDescription =
+    content.description ||
+    "Open-source tools, datasets, and documentation to advance computational immunooncology research. All resources are freely available to the scientific community.";
 
   return (
     <section id="resources" className="py-20 bg-background">

--- a/src/components/renderers/CollaborationsRenderer.tsx
+++ b/src/components/renderers/CollaborationsRenderer.tsx
@@ -9,13 +9,14 @@ interface CollaborationsRendererProps {
 
 const CollaborationsRenderer = memo(({ content, className = "" }: CollaborationsRendererProps) => {
   const extractSection = (title: string) => {
-    const regex = new RegExp(`## ${title}[\\s\\S]*?(?=##|$)`);
+    const regex = new RegExp(`## ${title}[\\s\\S]*?(?=\n## [^#]|$)`);
     const match = content.match(regex);
     return match ? match[0] : '';
   };
 
   const parseCollaborations = (section: string) => {
-    const blocks = section.match(/###[^#][^\n]*[\s\S]*?(?=###|##|$)/g) || [];
+    const blocks =
+      section.match(/###[^#][^\n]*[\s\S]*?(?=###|\n## [^#]|$)/g) || [];
     return blocks.map((block) => {
       const title = block.match(/###\s+([^\n]+)/)?.[1] || '';
       const body = block.replace(/###\s+[^\n]+\n?/, '');


### PR DESCRIPTION
## Summary
- fix section extraction and parsing in `CollaborationsRenderer` so collaborations markdown renders correctly
- refactor `Collaborations` and `ResourcesTools` components to call hooks unconditionally

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892a35378a883249caa38024c8562bb