### PR TITLE
refactor: centralize markdown parsing utilities

### DIFF
--- a/src/utils/contentUtils.ts
+++ b/src/utils/contentUtils.ts
@@ -1,5 +1,4 @@
-import matter from 'gray-matter';
-import '../lib/buffer-polyfill';
+import { parseMarkdownModules } from './markdownUtils';
 
 export interface ContentMetadata {
   title: string;
@@ -10,27 +9,22 @@ export interface Content extends ContentMetadata {
   content: string;
 }
 
-// Import all content files
-const contentModules = import.meta.glob('/src/content/*.md', { 
+const contentModules = import.meta.glob('/src/content/*.md', {
   query: '?raw',
   import: 'default',
-  eager: true 
+  eager: true,
 });
+
+const contents = parseMarkdownModules<ContentMetadata>(contentModules);
 
 export const getContent = (filename: string): Content | undefined => {
   const path = `/src/content/${filename}.md`;
-  const rawContent = contentModules[path];
-  
-  if (!rawContent) {
+  const match = contents.find((c) => c.path === path);
+  if (!match) {
     return undefined;
   }
-  
-  const { data, content } = matter(rawContent as string);
-  
-  return {
-    ...(data as ContentMetadata),
-    content,
-  };
+  const { path: _path, ...content } = match;
+  return content;
 };
 
 export const getAboutContent = (): Content | undefined => {

--- a/src/utils/markdownUtils.ts
+++ b/src/utils/markdownUtils.ts
@@ -1,0 +1,18 @@
+import matter from 'gray-matter';
+import '../lib/buffer-polyfill';
+
+export interface MarkdownFile<T> extends T {
+  content: string;
+  path: string;
+}
+
+/**
+ * Convert a Vite import.meta.glob result into typed markdown objects.
+ * @param modules Result of import.meta.glob with `eager: true` and `?raw` query.
+ */
+export function parseMarkdownModules<T>(modules: Record<string, unknown>): MarkdownFile<T>[] {
+  return Object.entries(modules).map(([path, raw]) => {
+    const { data, content } = matter(raw as string);
+    return { ...(data as T), content, path };
+  });
+}

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -1,5 +1,4 @@
-import matter from 'gray-matter';
-import '../lib/buffer-polyfill';
+import { parseMarkdownModules } from './markdownUtils';
 
 export interface ProfileMetadata {
   id: string;
@@ -23,32 +22,28 @@ export interface Profile extends ProfileMetadata {
   content: string;
 }
 
-const profileModules = import.meta.glob('/src/profiles/*.md', { 
+const profileModules = import.meta.glob('/src/profiles/*.md', {
   query: '?raw',
   import: 'default',
-  eager: true 
+  eager: true,
 });
 
-export const getAllProfiles = (): Profile[] => {
-  const profiles: Profile[] = [];
-  
-  Object.entries(profileModules).forEach(([path, content]) => {
-    const { data, content: markdownContent } = matter(content as string);
-    profiles.push({
-      ...(data as ProfileMetadata),
-      content: markdownContent,
-    });
-  });
-  
-  const positionOrder = ['Principal Investigator', 'Postdoctoral Research Fellow', 'PhD Student'];
-  return profiles.sort((a, b) => {
-    const aOrder = positionOrder.findIndex(pos => a.position.includes(pos));
-    const bOrder = positionOrder.findIndex(pos => b.position.includes(pos));
+const positionOrder = [
+  'Principal Investigator',
+  'Postdoctoral Research Fellow',
+  'PhD Student',
+];
+
+const profiles: Profile[] = parseMarkdownModules<ProfileMetadata>(profileModules)
+  .map(({ path, ...profile }) => profile)
+  .sort((a, b) => {
+    const aOrder = positionOrder.findIndex((pos) => a.position.includes(pos));
+    const bOrder = positionOrder.findIndex((pos) => b.position.includes(pos));
     return aOrder - bOrder;
   });
-};
+
+export const getAllProfiles = (): Profile[] => profiles;
 
 export const getProfileById = (id: string): Profile | undefined => {
-  const profiles = getAllProfiles();
-  return profiles.find(profile => profile.id === id);
+  return profiles.find((profile) => profile.id === id);
 };


### PR DESCRIPTION
## Summary
- reduce repeated logic by introducing a shared markdown parsing helper
- refactor posts, profiles, projects, and content loaders to use the new helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892a5feda608324961945a82b7a2998