### PR TITLE
style: unify home page buttons and headings

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -10,7 +10,7 @@ const BlogSection = () => {
     <section id="blog" className="py-20 bg-background">
       <div className="container mx-auto px-4">
         <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6 text-foreground">
+          <h2 className="text-4xl md:text-5xl font-bold mb-6 text-muted-foreground">
             Latest Research Posts
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
@@ -25,7 +25,11 @@ const BlogSection = () => {
         </div>
 
         <div className="text-center">
-          <Button size="lg" className="px-8" asChild>
+          <Button
+            size="lg"
+            className="px-8 transition-transform hover:scale-105"
+            asChild
+          >
             <Link to="/blog">View All Posts</Link>
           </Button>
         </div>

--- a/src/components/Collaborations.tsx
+++ b/src/components/Collaborations.tsx
@@ -61,7 +61,7 @@ const Collaborations = () => {
     <section id="collaborations" className="py-20 bg-background">
       <div className="container mx-auto px-4">
         <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6 text-foreground">
+          <h2 className="text-4xl md:text-5xl font-bold mb-6 text-muted-foreground">
             {sectionTitle.split(' ').map((word, index) =>
               index === 1 ? <span key={index} className="text-primary">{word}</span> : word + ' '
             )}
@@ -98,12 +98,16 @@ const Collaborations = () => {
         </div>
 
         <div className="text-center">
-          <Link to="/collaborations">
-            <Button size="lg" className="group">
+          <Button
+            asChild
+            size="lg"
+            className="px-8 group transition-transform hover:scale-105"
+          >
+            <Link to="/collaborations" className="flex items-center gap-2">
               View All Collaborations
-              <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
-            </Button>
-          </Link>
+              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+            </Link>
+          </Button>
         </div>
       </div>
     </section>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -8,11 +8,11 @@ const Contact = () => {
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-bold mb-6 text-foreground">
+            <h2 className="text-4xl md:text-5xl font-bold mb-6 text-muted-foreground">
               Get In Touch
             </h2>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              Interested in collaboration, have questions about my research, or want to discuss computational biology? 
+              Interested in collaboration, have questions about my research, or want to discuss computational biology?
               I'd love to hear from you.
             </p>
           </div>
@@ -64,19 +64,31 @@ const Contact = () => {
 
           <div className="text-center">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-              <Button variant="outline" className="flex items-center gap-2 h-12">
+              <Button
+                variant="outline"
+                className="flex items-center gap-2 h-12 transition-transform hover:scale-105"
+              >
                 <Mail className="h-5 w-5" />
                 <span className="hidden sm:inline">Email</span>
               </Button>
-              <Button variant="outline" className="flex items-center gap-2 h-12">
+              <Button
+                variant="outline"
+                className="flex items-center gap-2 h-12 transition-transform hover:scale-105"
+              >
                 <Github className="h-5 w-5" />
                 <span className="hidden sm:inline">GitHub</span>
               </Button>
-              <Button variant="outline" className="flex items-center gap-2 h-12">
+              <Button
+                variant="outline"
+                className="flex items-center gap-2 h-12 transition-transform hover:scale-105"
+              >
                 <Linkedin className="h-5 w-5" />
                 <span className="hidden sm:inline">LinkedIn</span>
               </Button>
-              <Button variant="outline" className="flex items-center gap-2 h-12">
+              <Button
+                variant="outline"
+                className="flex items-center gap-2 h-12 transition-transform hover:scale-105"
+              >
                 <Twitter className="h-5 w-5" />
                 <span className="hidden sm:inline">Twitter</span>
               </Button>
@@ -88,7 +100,10 @@ const Contact = () => {
                 I'm always interested in discussing new research projects, reviewing manuscripts, 
                 speaking at conferences, or consulting on bioinformatics challenges.
               </p>
-              <Button size="lg" className="px-8">
+              <Button
+                size="lg"
+                className="px-8 transition-transform hover:scale-105"
+              >
                 Send Message
               </Button>
             </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,9 +8,6 @@ const Header = () => {
         <nav className="flex items-center justify-between">
           <div className="flex flex-col">
             <div className="font-bold text-xl text-primary">LIIA</div>
-            <div className="text-xs text-muted-foreground">
-              Laboratório de pesquisa em Imunooncologia e Inteligência Artificial
-            </div>
           </div>
           <div className="hidden md:flex items-center space-x-8">
             <Link to="/" className="text-foreground hover:text-primary transition-colors">
@@ -41,7 +38,10 @@ const Header = () => {
               Contact
             </a>
           </div>
-          <Button variant="outline" className="md:hidden">
+          <Button
+            variant="outline"
+            className="md:hidden transition-transform hover:scale-105"
+          >
             Menu
           </Button>
         </nav>

--- a/src/components/LaboratoryVision.tsx
+++ b/src/components/LaboratoryVision.tsx
@@ -22,20 +22,24 @@ const LaboratoryVision = () => {
     <section id="vision" className="py-20 bg-muted/30">
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-bold mb-6 text-foreground">
-              Laboratory Vision
-            </h2>
-            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Our mission and guiding principles in computational biology research.
-            </p>
-          </div>
+        <div className="text-center mb-16">
+          <h2 className="text-4xl md:text-5xl font-bold mb-6 text-muted-foreground">
+            Laboratory Vision
+          </h2>
+          <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
+            Our mission and guiding principles in computational biology research.
+          </p>
+        </div>
           <MarkdownRenderer 
             content={visionContent.content} 
             type="laboratory-vision"
           />
           <div className="text-center mt-12">
-            <Button size="lg" className="px-8" asChild>
+            <Button
+              size="lg"
+              className="px-8 transition-transform hover:scale-105"
+              asChild
+            >
               <Link to="/people">Meet Our People</Link>
             </Button>
           </div>

--- a/src/components/Publications.tsx
+++ b/src/components/Publications.tsx
@@ -21,15 +21,15 @@ const Publications = () => {
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-bold mb-6 text-foreground">
+            <h2 className="text-4xl md:text-5xl font-bold mb-6 text-muted-foreground">
               Publications
             </h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               Our research contributions to computational biology and machine learning.
             </p>
           </div>
-          <MarkdownRenderer 
-            content={publicationsContent.content} 
+          <MarkdownRenderer
+            content={publicationsContent.content}
             type="publications"
           />
         </div>

--- a/src/components/Research.tsx
+++ b/src/components/Research.tsx
@@ -32,7 +32,7 @@ const Research = () => {
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-bold mb-6 text-foreground">
+            <h2 className="text-4xl md:text-5xl font-bold mb-6 text-muted-foreground">
               Research Lines
             </h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
@@ -69,10 +69,14 @@ const Research = () => {
           </div>
           
           <div className="text-center mt-12">
-            <Button asChild size="lg" className="hover-scale">
+            <Button
+              asChild
+              size="lg"
+              className="px-8 group transition-transform hover:scale-105"
+            >
               <Link to="/research" className="flex items-center gap-2">
                 View All Projects
-                <ArrowRight className="h-4 w-4" />
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
               </Link>
             </Button>
           </div>

--- a/src/components/ResourcesTools.tsx
+++ b/src/components/ResourcesTools.tsx
@@ -79,7 +79,7 @@ const ResourcesTools = () => {
     <section id="resources" className="py-20 bg-muted/30">
       <div className="container mx-auto px-4">
         <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6 text-foreground">
+          <h2 className="text-4xl md:text-5xl font-bold mb-6 text-muted-foreground">
             {sectionTitle.split(' ').slice(0, 1)} <span className="text-primary">{sectionTitle.split(' ').slice(1).join(' ')}</span>
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
@@ -123,12 +123,16 @@ const ResourcesTools = () => {
         </div>
 
         <div className="text-center">
-          <Link to="/resources">
-            <Button size="lg" className="group">
+          <Button
+            asChild
+            size="lg"
+            className="px-8 group transition-transform hover:scale-105"
+          >
+            <Link to="/resources" className="flex items-center gap-2">
               Explore All Resources
-              <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
-            </Button>
-          </Link>
+              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+            </Link>
+          </Button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Standardize home page button styling and hover effects
- Remove tagline from navigation header
- Render section headings in light gray across the home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68936412565c8324b442a1f9baf71ff2